### PR TITLE
Cyber NJ Logo Spacing interfering with the Footer of the Website

### DIFF
--- a/index.html
+++ b/index.html
@@ -703,8 +703,12 @@
 
             <div class="row2" style="padding-top: 250px; padding-left: 10%; padding-right: 10%;">
                 <div class="column" style="display: block; margin-left: auto; margin-right: auto; width: 30%;">
-                    <a href="https://www.cyber.nj.gov/"><img src="images/NJCCIC_Logo.png"></a>
+                    <a href="https://www.cyber.nj.gov/"><img src="images/NJCCIC_Logo.png" style="max-width:100%;height:auto;"></a>
                 </div>
+            </div>
+
+            <!--Adding spacing to properly format the cyber nj logo against the footer-->
+            <div class="row2" style="padding-top:0-px; padding-left: 10%; padding-right: 10%;">
             </div>
         
         <!--
@@ -738,7 +742,7 @@
 
     <!-- footer
     ================================================== -->
-    <footer style="padding-top: 0px; padding-bottom: 30px">
+    <footer style="padding-top: 5px; padding-bottom: 30px">
         <div class="row footer-bottom">
 
             <div class="col-twelve">


### PR DESCRIPTION
Originally on some devices, the cyber NJ logo would interfere with the footer, bleeding into it. I added the following lines in the index.html file at line 710: 
 <!--Adding spacing to properly format the cyber nj logo against the footer-->
            <div class="row2" style="padding-top:0-px; padding-left: 10%; padding-right: 10%;">
            </div>

I added a small row to in between the footer and the logo to make sure that it doesn't bleed on some devices.